### PR TITLE
Add article on Buckminster Fuller as precursor to SBDT

### DIFF
--- a/docs/article_buckminster_fuller.md
+++ b/docs/article_buckminster_fuller.md
@@ -1,0 +1,65 @@
+Buckminster Fuller and the Path Toward Sphere-Based Design Theory
+================================================================
+
+Introduction
+------------
+
+R. Buckminster Fuller (1895–1983) was a designer, inventor, and visionary who believed design could solve humanity’s most urgent challenges. He is best known for his geodesic dome, but his contributions extend far beyond architecture. Fuller articulated a worldview in which geometry, efficiency, and ecology converged into a comprehensive design philosophy — a worldview that anticipates the principles of Sphere-Based Design Theory (SBDT).
+
+Fuller’s Core Contributions
+---------------------------
+
+1. Geodesic Domes
+
+Fuller popularized the geodesic dome as a lightweight, stable, and energy-efficient structure. By distributing stress evenly across a spherical surface, geodesic domes could cover vast spaces with minimal material.
+
+- **Mathematical Basis**: Derived from subdividing a sphere into triangular networks.
+- **Impact**: Used in pavilions, military shelters, greenhouses, and experimental communities.
+- **Relevance to SBDT**: Demonstrates how the sphere is the optimal form for balancing strength and efficiency.
+
+2. Dymaxion Principles
+
+Fuller’s “Dymaxion” projects (Dynamic Maximum Tension) included the Dymaxion House and Dymaxion Car. These sought to minimize energy use and maximize human potential through design.
+
+- **Efficiency**: Minimum resource input, maximum functional output.
+- **Systems Thinking**: Fuller framed each design as part of a global network, foreshadowing the systemic lens of SBDT.
+
+3. Synergetics
+
+Fuller’s magnum opus, *Synergetics*, proposed a geometry of thought rooted in tetrahedra, spheres, and vector equilibrium.
+
+- **Tetrahedron as Fundamental**: Fuller argued the tetrahedron, derived from spherical packing, was the basic unit of structure.
+- **Vector Equilibrium**: A state of perfect balance, modeled as a sphere of symmetrical vectors.
+- **Anticipation of SBDT**: Fuller’s “geometry of thinking” placed spherical and polyhedral relations at the heart of knowledge.
+
+Fuller’s Legacy in Context of SBDT
+----------------------------------
+
+### Spheres as Primordial Forms
+
+Fuller showed how spheres and their subdivisions could generate all practical structures. SBDT expands this: spheres are not just efficient forms but the origin of all forms, including cubes, pyramids, and polyhedra (via algorithmic morphogenesis).
+
+### Systems Thinking and Ecology
+
+Fuller coined the metaphor “Spaceship Earth,” urging humanity to see the planet as a closed spherical system requiring stewardship. SBDT carries this forward: architecture, AI cognition, and quantum information are all modeled as spherical systems of energy and flow.
+
+### Design Science → Symbolic Science
+
+Fuller called for a “design science revolution” — the application of design to solve global crises. SBDT builds on this by proposing a symbolic design science, where spheres are the substrate of cognition, computation, and built form.
+
+Toward Sphere-Based Design Theory
+---------------------------------
+
+Fuller laid the foundation for SBDT by:
+
+- Proving the sphere is the most efficient structural form.
+- Developing geometric languages (geodesics, vector equilibrium) that link spheres to polyhedra.
+- Advocating for planetary-scale design thinking, rooted in ecological awareness.
+
+SBDT builds on these insights, extending the role of spheres from architecture into cognitive systems, symbolic recursion, and quantum information. Where Fuller sought to redesign housing and cities, SBDT seeks to redesign the very foundations of how we think, build, and compute.
+
+Conclusion
+----------
+
+Buckminster Fuller’s vision was radical in his time, but it resonates powerfully today. His geodesic domes and synergetic geometry anticipated a future where spheres are not simply architectural curiosities but the blueprint of all design. Sphere-Based Design Theory inherits his mantle, pushing his principles into new territories: cognition, AI, and the symbolic architecture of information.
+


### PR DESCRIPTION
## Summary
- add `docs/article_buckminster_fuller.md`, outlining Buckminster Fuller's key ideas and how they anticipate Sphere-Based Design Theory (SBDT)

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b3bb4adc20832db1856fe1d86567c8